### PR TITLE
modify the search message to support unlimited select

### DIFF
--- a/LKDBHelper/Helper/LKDBHelper.m
+++ b/LKDBHelper/Helper/LKDBHelper.m
@@ -419,7 +419,11 @@ return NO;}
     {
         [sql appendFormat:@" order by %@",orderby];
     }
-    [sql appendFormat:@" limit %d offset %d",count,offset];
+    
+    // Add limit & offset only when count > 0
+    if (count > 0) {
+        [sql appendFormat:@" limit %d offset %d",count,offset];
+    }
 }
 - (NSMutableArray *)executeResult:(FMResultSet *)set Class:(Class)modelClass
 {


### PR DESCRIPTION
In the search message

``` objective-c
- (NSMutableArray *)search:(Class)modelClass where:(id)where orderBy:(NSString *)orderBy offset:(int)offset count:(int)count
```

if the count param is 0, the search count will be unlimited.
