### PR TITLE
去掉将 double 映射为 sqlite text 的限定

### DIFF
--- a/LKDBHelper/Helper/LKDBHelper.m
+++ b/LKDBHelper/Helper/LKDBHelper.m
@@ -625,10 +625,6 @@
 
         NSString* columnType = property.sqlColumnType;
 
-        if ([columnType isEqualToString:LKSQL_Type_Double]) {
-            columnType = LKSQL_Type_Text;
-        }
-
         [table_pars appendFormat:@"%@ %@", property.sqlColumnName, columnType];
 
         if ([property.sqlColumnType isEqualToString:LKSQL_Type_Text]) {


### PR DESCRIPTION
现在 sqlite3 里，double 类型占用 8 bytes，对于一般的 double 类型的数据，也基本够用，无需以 text 来容纳