### PR TITLE
fix NSString to NSNumber bug

### DIFF
--- a/LKDBHelper/Helper/NSObject+LKModel.m
+++ b/LKDBHelper/Helper/NSObject+LKModel.m
@@ -287,7 +287,9 @@ static char LKModelBase_Key_Inserting;
         modelValue = value;
     }
     else if ([columnClass isSubclassOfClass:[NSNumber class]]) {
-        modelValue = [NSNumber numberWithDouble:[value doubleValue]];
+        //应该用格式化的方式转换,[NSNumber numberWithDouble:[value doubleValue]]会导致下次使用该数值查询的时候查不到结果
+        NSNumberFormatter *numberFormatter = [[NSNumberFormatter alloc] init];
+        modelValue = [numberFormatter numberFromString:value];
     }
     else if ([columnClass isSubclassOfClass:[NSDate class]]) {
         NSString* datestr = [value stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];


### PR DESCRIPTION
else if ([columnClass isSubclassOfClass:[NSNumber class]]) {
        //应该用格式化的方式转换,[NSNumber numberWithDouble:[value doubleValue]]会导致下次使用该数值查询的时候查不到结果
        NSNumberFormatter *numberFormatter = [[NSNumberFormatter alloc] init];
        modelValue = [numberFormatter numberFromString:value];
    }