### PR TITLE
去掉 与 getModelInfo 中重复的 获取superClass 的属性 的代码

### DIFF
--- a/LKDBHelper.podspec.json
+++ b/LKDBHelper.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "LKDBHelper",
-  "version": "2.1.7",
+  "version": "2.2.1",
   "summary": "全自动的插入,查询,更新,删除， an automatic database operation thread-safe and not afraid of recursive deadlock",
   "description": "全面支持 NSArray,NSDictionary, ModelClass, NSNumber, NSString, NSDate, NSData, UIColor, UIImage, CGRect, CGPoint, CGSize, NSRange, int,char,float, double, long.. 等属性的自动化操作(插入和查询)",
   "homepage": "https://github.com/li6185377/LKDBHelper-SQLite-ORM",

--- a/LKDBHelper.podspec.json
+++ b/LKDBHelper.podspec.json
@@ -9,8 +9,8 @@
     "Jianghuai Li": "li6185377@163.com"
   },
   "source": {
-    "git": "https://github.com/li6185377/LKDBHelper-SQLite-ORM.git",
-    "tag": "2.1.7"
+    "git": "https://github.com/goodbless/LKDBHelper-SQLite-ORM.git",
+    "branch": "gongke"
   },
   "platforms": {
     "ios": "4.3",

--- a/LKDBHelper.podspec.json
+++ b/LKDBHelper.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "LKDBHelper",
-  "version": "2.2.1",
+  "version": "2.3",
   "summary": "全自动的插入,查询,更新,删除， an automatic database operation thread-safe and not afraid of recursive deadlock",
   "description": "全面支持 NSArray,NSDictionary, ModelClass, NSNumber, NSString, NSDate, NSData, UIColor, UIImage, CGRect, CGPoint, CGSize, NSRange, int,char,float, double, long.. 等属性的自动化操作(插入和查询)",
   "homepage": "https://github.com/li6185377/LKDBHelper-SQLite-ORM",

--- a/LKDBHelper/Helper/NSObject+LKModel.m
+++ b/LKDBHelper/Helper/NSObject+LKModel.m
@@ -884,9 +884,6 @@ static char LKModelBase_Key_Inserting;
         [protypes addObject:propertyClassName];
     }
     free(properties);
-    if ([self isContainParent] && [self superclass] != [NSObject class]) {
-        [[self superclass] getSelfPropertys:pronames protypes:protypes];
-    }
 }
 
 #pragma mark - log all property


### PR DESCRIPTION
在getModelInfos方法中，会去获取super 的 ModelInfo，里面已经包含了super的属性，但是在getSelfPropertys: protypes: 方法中又去获取了super的属性，导致最终获取的属性重复了。虽然在最后添加到_rpoNameDic 和 _sqlNameDic的过程中，因为key的唯一性，重复的数据被过滤掉了。但是会导致super中Maping和对自己属性的处理失效