### PR TITLE
Update LKDBUtils.m

### DIFF
--- a/LKDBHelper/Helper/LKDBUtils.m
+++ b/LKDBHelper/Helper/LKDBUtils.m
@@ -17,7 +17,7 @@
     self = [super init];
     if (self) {
         self.lock = [[NSRecursiveLock alloc] init];
-        self.generatesCalendarDates = YES;
+        self.generatesCalendarDates = NO;
         self.dateStyle = NSDateFormatterNoStyle;
         self.timeStyle = NSDateFormatterNoStyle;
         self.AMSymbol = nil;


### PR DESCRIPTION
This property is YES if the formatter generates the deprecated NSCalendarDate type, and is NO otherwise. You should use NSDate and NSCalendar rather than NSCalendarDate.

https://developer.apple.com/documentation/foundation/nsdateformatter/1411107-generatescalendardates?language=objc